### PR TITLE
Env setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ Exports/
 export.cfg
 export_presets.cfg
 addons/
+
+# Mono-specific ignores
+.mono/
+data_*/

--- a/project.godot
+++ b/project.godot
@@ -102,6 +102,10 @@ interact={
  ]
 }
 
+[mono]
+
+project/assembly_name="Ritual Game"
+
 [physics]
 
 common/enable_pause_aware_picking=true


### PR DESCRIPTION
Gitignore to ignore mono files, and also a small project update that happens automagically I guess because I have the mono version.

If I should just download the non-mono version of Godot I can do that too.