### PR TITLE
Daynight cycle PoC

### DIFF
--- a/Scenes/DayNight/DayNight.gd
+++ b/Scenes/DayNight/DayNight.gd
@@ -1,0 +1,61 @@
+# Thanks BitBrain and Devduck!!
+
+extends CanvasModulate
+class_name DayNightCycle
+
+enum TimeMode {
+	INGAME,
+	STATIC,
+	SYSTEM
+}
+
+enum StaticTime {
+	MORNING = 70,
+	NOON = 100,
+	EVENING = 80,
+	NIGHT = 0
+}
+
+const GROUP_NAME: String = "DayNightCycle"
+const NIGHT_COLOR: Color = Color("#091d3a")
+const DAY_COLOR: Color = Color("#ffffff")
+const EVENING_COLOR: Color = Color("#ff3300")
+const HALF_DAY_IN_SECONDS: float = 60.0 * 60.0 * 12.0
+
+export(TimeMode) var time_mode = TimeMode.STATIC
+export(StaticTime) var static_time = StaticTime.NOON
+export var time_scale: float = 1.0
+
+var time = 0
+var expected_color: Color
+var darkness: float = 0
+
+func _process(delta: float) -> void:
+	var value: float
+	
+	match time_mode:
+		TimeMode.INGAME:
+			self.time += delta * time_scale
+			value = (sin(time) + 1) / 2	# 0 is midnight, 1 is high noon
+		TimeMode.STATIC:
+			value = static_time / 100.0
+		TimeMode.SYSTEM:
+			var current_seconds = _seconds_from_time(OS.get_time())
+			var over_twelve = current_seconds - HALF_DAY_IN_SECONDS
+			if over_twelve > 0:
+				var adjusted_seconds = HALF_DAY_IN_SECONDS - over_twelve
+				value = adjusted_seconds / HALF_DAY_IN_SECONDS
+			else:
+				value = current_seconds / HALF_DAY_IN_SECONDS
+
+	expected_color = get_source_colour(value).linear_interpolate(get_target_colour(value), value)
+	self.color = expected_color.darkened(darkness)
+			
+func get_source_colour(value):
+	return NIGHT_COLOR.linear_interpolate(EVENING_COLOR, value)
+
+func get_target_colour(value):
+	return EVENING_COLOR.linear_interpolate(DAY_COLOR, value)
+
+func _seconds_from_time(time_dict: Dictionary) -> float:
+	return (time_dict["hour"] * 60.0 * 60.0) + (time_dict["minute"] * 60.0) + time_dict["second"]

--- a/Scenes/DayNight/DayNight.tscn
+++ b/Scenes/DayNight/DayNight.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://Scenes/DayNight/DayNight.gd" type="Script" id=1]
+
+[node name="DayNightCycle" type="CanvasModulate"]
+color = Color( 0.0352941, 0.113725, 0.227451, 1 )
+script = ExtResource( 1 )

--- a/Scenes/TravelScene/TravelScene.tscn
+++ b/Scenes/TravelScene/TravelScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://Assets/Original/Textures/DallEClothMap.png" type="Texture" id=1]
 [ext_resource path="res://Scenes/LocationMarker/LocationMarker.tscn" type="PackedScene" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://Scenes/TravelScene/TravelScene.gd" type="Script" id=5]
 [ext_resource path="res://Resources/Locations/CommunalHymn.tres" type="Resource" id=6]
 [ext_resource path="res://Resources/Locations/TeaCeremony.tres" type="Resource" id=7]
+[ext_resource path="res://Scenes/DayNight/DayNight.tscn" type="PackedScene" id=8]
 
 [node name="TravelScene" type="Node2D"]
 script = ExtResource( 5 )
@@ -45,3 +46,7 @@ margin_top = -413.0
 margin_right = -351.0
 margin_bottom = -349.0
 location_data = ExtResource( 7 )
+
+[node name="DayNightCycle" parent="." instance=ExtResource( 8 )]
+time_mode = 0
+time_scale = 0.6


### PR DESCRIPTION
Not gonna lie, Devduck had a fantastic walkthrough on this.

Saved this to a DayNightCycle scene. You can use the TimeScale setting to decide if it should be an static time of day, in-game timescale-based, or OS system time (in case we really do want to go that route).

*Note timescale defaults to 1 so it moves through the colors pretty fast. And also, I think we'll want to move that time_scale variable out to Appsettings or somewhere where it will be accessible by whatever logic we use for the Ritual Retry timer. So that can move at a similarly fast speed.